### PR TITLE
Reviews second quarter of reading list

### DIFF
--- a/_people/AyannaHoward.md
+++ b/_people/AyannaHoward.md
@@ -6,7 +6,7 @@ school: Ohio State University
 website: https://engineering.osu.edu/people/howard.1727
 image: https://people.engineering.osu.edu/sites/default/files/styles/coe_3_4_medium/public/2021-05/Dean_Howard_-_web_portrait.jpg
 ---
-Prof. Howard's research is centered around applying human-inspired techniques to intelligent systems. She has also done significant work in improving robotics education for students of all ages: from childhood all the way to graduate-level education.
+Prof. Howard's research is centered around applying human-inspired techniques to intelligent systems. Prof. Howard is the founder and president of the board of directors of Zyrobotics, a company that develops mobile therapy and educational products for children with special needs. She has also done significant work in improving robotics education for students of all ages: from childhood all the way to graduate-level education.
 * M. Schrum, C. H. Park and A. Howard, "[Humanoid Therapy Robot for Encouraging Exercise in Dementia Patients](https://ieeexplore.ieee.org/abstract/document/8673155)," _ACM/IEEE International Conference on Human-Robot Interaction (HRI)_, Daegu, Korea (South), pp. 564-565, 2019.
 * J. Borenstein, A. R. Wagner and A. Howard, "[Overtrust of Pediatric Health-Care Robots: A Preliminary Survey of Parent Perspectives](https://ieeexplore.ieee.org/abstract/document/8279643)," in _IEEE Robotics & Automation Magazine_, vol. 25, no. 1, pp. 46-54, March 2018.
 * A. Howard and J. Borenstein. "[The ugly truth about ourselves and our robot creations: the problem of bias and social inequity](https://link.springer.com/article/10.1007/s11948-017-9975-2)." _Science and Engineering Ethics_, vol. 24, no. 5, pp. 1521-1536, 2018.

--- a/_people/CharlesIsbell.md
+++ b/_people/CharlesIsbell.md
@@ -4,7 +4,7 @@ last_name: Isbell
 title: Provost and Vice Chancellor for Academic Affairs and Hilldale Professor
 school: University of Wisconsin–Madison
 website: https://provost.wisc.edu/meet-the-provost/
-image: https://static01.nyt.com/images/2016/10/05/upshot/05up-masters/29UP-Masters-superJumbo.jpg
+image: https://provost.wisc.edu/wp-content/uploads/sites/181/2023/08/Isbell-Charles-web_cropped_200.jpg
 ---
 Provost Isbell's research focuses on designing systems that are capable of interacting with one another and with humans in reasonable ways using techniques such as machine learning and game theory. Provost Isbell founded the [pfunk](https://www.cc.gatech.edu/~isbell/iai/people.shtml) research group within the Lab for Interactive Artificial Intelligence at Georgia Tech.
 * Bansal, Shray, et al. "[A Bayesian Framework for Nash Equilibrium Inference in Human-Robot Parallel Play](https://www.cc.gatech.edu/~isbell/papers/pplay_rss2020.pdf)." _Robotics: Science and Systems_ (2020).

--- a/_people/ChinweEkenna.md
+++ b/_people/ChinweEkenna.md
@@ -1,8 +1,8 @@
 ---
 first_name: Chinwe  
 last_name: Ekenna
-title: Assistant Professor of Computer Science
-school: University of Albany
+title: Associate Professor of Computer Science
+school: University at Albany
 website: https://www.albany.edu/computer-science/faculty/chinwe-ekenna
 image: https://www.albany.edu/sites/default/files/styles/person_page_thumbnail/public/2016_10_25_Chinwe%20Ekenna_10.jpg
 ---

--- a/_people/ChrisCrawford.md
+++ b/_people/ChrisCrawford.md
@@ -7,6 +7,7 @@ website: http://www.chrissmithcrawford.com/
 image: https://images.squarespace-cdn.com/content/v1/5d7fd241e8251322d42fd2b9/1613321959168-AR3RO540APJU7AE15V00/ke17ZwdGBToddI8pDm48kJpJ1fPc8kLIjpwta9BaF297gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QHyNOqBUUEtDDsRWrJLTmW5SZw0zY0wEgct1jJcv4nLlRh82_3jCwPE9ddhuyc0PMSp0K4gWLaEuRob08_9Ys/chris_crawford_headshot.jpg?format=500w
 ---
 Prof. Crawford directs the [Human-Technology Interaction Lab](https://htilua.org/). His work focuses on Brain-Computer Interfaces (BCI) and Human-Robot Interaction (HRI).
+
+* Stegman, P. et al. "[Brain-Computer Interface Software: A Review and Discussion.](https://ieeexplore.ieee.org/abstract/document/8995646)" _IEEE Transactions on Human-Machine Systems, Volume 50, Issue 2, (2020): 101-115.
 * Andujar, Marvin, et al. "[Artistic Brain-Computer Interfaces: the Expression and Stimulation of the User’s Affective State.](https://www.tandfonline.com/doi/abs/10.1080/2326263X.2015.1104613)" _Brain-Computer Interfaces_ 2.2-3 (2015): 60-69.
-* Crawford, Chris S. and Gilbert, Juan E. "[Brains and Blocks: Introducing Novice Programmers to Brain-Computer Interface Application Development.](https://dl.acm.org/doi/abs/10.1145/3335815?casa_token=Da_7C-kUpvAAAAAA:qb3fI4JXkx5-_tXnfg5FX46UGuserNEfSxsKsOcuEV5lTfmqj_lDXYemXZs071QZu7Trs4ovs0OaDEI)" _ACM Transactions on Computing Education_ 19, no. 4 (2019): 1-27.
 * Gurbuz, Sevgi Z., et al. "[American Sign Language Recognition Using RF Sensing.](https://www.semanticscholar.org/paper/American-Sign-Language-Recognition-Using-RF-Sensing-Gurbuz-Gurbuz/f4f6f722e1419c4c96a8687333e289eab1769ca1)" _IEEE Sensors Journal_ 21 (2020): 3763-3775.

--- a/_people/ChrisCrawford.md
+++ b/_people/ChrisCrawford.md
@@ -8,6 +8,6 @@ image: https://images.squarespace-cdn.com/content/v1/5d7fd241e8251322d42fd2b9/16
 ---
 Prof. Crawford directs the [Human-Technology Interaction Lab](https://htilua.org/). His work focuses on Brain-Computer Interfaces (BCI) and Human-Robot Interaction (HRI).
 
-* Stegman, P. et al. "[Brain-Computer Interface Software: A Review and Discussion.](https://ieeexplore.ieee.org/abstract/document/8995646)" _IEEE Transactions on Human-Machine Systems, Volume 50, Issue 2, (2020): 101-115.
+* Stegman, P. et al. "[Brain-Computer Interface Software: A Review and Discussion.](https://ieeexplore.ieee.org/abstract/document/8995646)" _IEEE Transactions on Human-Machine Systems_, Volume 50, Issue 2, (2020): 101-115.
 * Andujar, Marvin, et al. "[Artistic Brain-Computer Interfaces: the Expression and Stimulation of the User’s Affective State.](https://www.tandfonline.com/doi/abs/10.1080/2326263X.2015.1104613)" _Brain-Computer Interfaces_ 2.2-3 (2015): 60-69.
 * Gurbuz, Sevgi Z., et al. "[American Sign Language Recognition Using RF Sensing.](https://www.semanticscholar.org/paper/American-Sign-Language-Recognition-Using-RF-Sensing-Gurbuz-Gurbuz/f4f6f722e1419c4c96a8687333e289eab1769ca1)" _IEEE Sensors Journal_ 21 (2020): 3763-3775.

--- a/_people/ChristineAllenBlanchette.md
+++ b/_people/ChristineAllenBlanchette.md
@@ -8,8 +8,8 @@ image: https://mae.princeton.edu/sites/default/files/styles/person_detail/public
 ---
 Christine Allen-Blanchette's research interests lie at the intersection of deep learning, geometry and dynamical systems. Her recent work includes physics-informed video generation and models for agent interactions. 
 
-* Yulong Yang, Bowen Feng, Keqin Wang, Naomi Leonard, Adji Bousso Dieng, and Christine Allen-Blanchette. "[Behavior-Inspired Neural Networks for Relational Inference.](https://arxiv.org/abs/2406.14746)" arXiv preprint arXiv:2406.14746 (2024).
+* Yulong Yang, Bowen Feng, Keqin Wang, Naomi Leonard, Adji Bousso Dieng, and Christine Allen-Blanchette. "[Behavior-Inspired Neural Networks for Relational Inference.](https://arxiv.org/abs/2406.14746)" AISTATS (2025).
 * Justice J. Mason\*, Christine Allen-Blanchette\*, Nicholas Zolman, Elizabeth Davison, and Naomi Ehrich Leonard. "[Learning to predict 3D rotational dynamics from images of a rigid body with unknown mass distribution.](https://www.mdpi.com/2226-4310/10/11/921)" Aerospace 10, no. 11 (2023): 921.
-* Christine Allen-Blanchette, Sushant Veer, Anirudha Majumdar, and Naomi Ehrich Leonard. "[Lagnetvip: A lagrangian neural network for video prediction.](https://arxiv.org/pdf/2010.12932.pdf)" arXiv preprint arXiv:2010.12932 (2020).
+* Christine Allen-Blanchette, Sushant Veer, Anirudha Majumdar, and Naomi Ehrich Leonard. "[LagNetViP: A lagrangian neural network for video prediction.](https://arxiv.org/pdf/2010.12932.pdf)" arXiv preprint arXiv:2010.12932 (2020).
 
 \* : Equal contribution

--- a/_people/DanielJacobs.md
+++ b/_people/DanielJacobs.md
@@ -1,12 +1,12 @@
 ---
 first_name: Daniel
 last_name: Jacobs
-title: Assistant Professor of Mechanical Engineering
-school: Temple University 
-website: https://engineering.temple.edu/about/faculty-staff/daniel-a-jacobs-tug91537
+title: Chair, Engineering and Robotics Department
+school: Springside Chestnut Hill Academy
+website: https://www.linkedin.com/in/daniel-jacobs-54842014/
 image: https://sites.temple.edu/rise/files/2017/02/DanielJacobsSmall-300x287.jpg
 ---
-Prof. Jacobs leads the [Robotics in Interdisciplinary Science and Engineering (RISE) Lab](https://sites.temple.edu/rise/). His primary research focus is in wearable robotics and augmenting human gait performance.
+Dr. Jacobs is the Chair of the Engineering and Robotics Department and Springside Chestnut Hill Academy. His primary research focus is in wearable robotics and augmenting human gait performance.
 * Canete, S. & Jacobs, D.A. "[Novel velocity estimation for symmetric and asymmetric self-paced treadmill training](https://dx.doi.org/10.1186/s12984-021-00825-3)". _Journal of NeuroEngineering and Rehabilitation_, vol. 18, 2021.
 * Jacobs, D.A., Koller, J.R., Steele, K.M. et al. "[Motor modules during adaptation to walking in a powered ankle exoskeleton](https://doi.org/10.1186/s12984-017-0343-x)". _Journal of NeuroEngineering and Rehabilitation_, vol. 15, 2018.
 * Jacobs, D.A., Ferris, D.P. "[Estimation of ground reaction forces and ankle moment with multiple, low-cost sensors](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4606964/)". _Journal of NeuroEngineering and Rehabilitation_, vol. 12, 2015.

--- a/_people/MaynardHolliday.md
+++ b/_people/MaynardHolliday.md
@@ -1,7 +1,7 @@
 ---
 first_name: Maynard
 last_name: Holliday, MSc
-title: Assistant Secretary of Defense for Critical Technologies
+title: (former) Assistant Secretary of Defense for Critical Technologies
 school: Office of the Under Secretary of Defense, Research and Engineering 
 website: https://www.defense.gov/About/Biographies/Biography/Article/2762694/maynard-holliday/
 image: https://images.squarespace-cdn.com/content/v1/5ef3dc8b4ce85b460be19b98/1593134579117-6429CSDX5QGV3BBYY6UR/ke17ZwdGBToddI8pDm48kEi6jd-8FPnQ8D-LERa9tzJZw-zPPgdn4jUwVcJE1ZvWEtT5uBSRWt4vQZAgTJucoTqqXjS3CfNDSuuf31e0tVHJpvhFKnKUeVj4Qkkq6mGHPKjS-e_5BAMjsJWrZPFRtgwOTLmG3bsrBAwDNZFfO_U/Maynard.SES.jpeg?format=1000w

--- a/_people/OdestJenkins.md
+++ b/_people/OdestJenkins.md
@@ -1,12 +1,12 @@
 ---
 first_name: Odest Chadwicke
 last_name: Jenkins
-title: Associate Chair of Undergraduate Studies and Professor of Robotics
+title: Founding Chair of Michigan Robotics Undergraduate Program and Professor of Robotics
 school: University of Michigan
 website: https://ocj.name/
 image: https://ocj.name/images/jenkins_um_small.jpg
 ---
-Prof. Jenkins leads the [Laboratory for Progress](http://progress.eecs.umich.edu/) and is Associate Chair of Undergraduate Studies for the Michigan Robotics Institute. His research addresses problems in interactive robotics and human-robot interaction, primarily focused on mobile manipulation, robot perception, and robot learning from demonstration.  Prof. Jenkins does not believe celebrity lists alone will lead to systemic fairness in robotics and its [merit review and support of Black roboticists at all levels](https://venturebeat.com/2020/08/08/before-we-put-100-billion-into-ai/).
+Prof. Jenkins leads the [Laboratory for Progress](http://progress.eecs.umich.edu/) and is founding Chair of the Michigan Robotics Undergraduate Program. His research addresses problems in interactive robotics and human-robot interaction, primarily focused on mobile manipulation, robot perception, and robot learning from demonstration.  Prof. Jenkins does not believe celebrity lists alone will lead to systemic fairness in robotics and its [merit review and support of Black roboticists at all levels](https://venturebeat.com/2020/08/08/before-we-put-100-billion-into-ai/).
 * Fod, Ajo, Maja J. Matarić, and Odest Chadwicke Jenkins. "[Automated derivation of primitives for movement classification.](http://ocj.name/papers/ar2002_fod.pdf)" Autonomous robots 12.1 (2002): 39-54.
 * Crick, Christopher, et al. "[Rosbridge: ROS for non-ROS users.](http://www.cs.okstate.edu/~chriscrick/Crick-TAR-16.pdf)" Robotics Research. Springer, Cham, 2017. 493-504. [Open source: Robot Web Tools](https://github.com/RobotWebTools/rosbridge_suite)
 * Sui, Zhiqiang, et al. "[SUM: Sequential scene understanding and manipulation.](https://arxiv.org/pdf/1703.07491.pdf)" 2017 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). IEEE, 2017.

--- a/_people/RalphEtienneCummings.md
+++ b/_people/RalphEtienneCummings.md
@@ -1,12 +1,12 @@
 ---
 first_name: Ralph
 last_name: Etienne-Cummings
-title: Professor of Electrical & Computer Engineering
+title: Julian S. Smith Professor of Electrical & Computer Engineering
 school: Johns Hopkins University
 website: https://engineering.jhu.edu/ece/faculty/etienne-cummings-ralph/
 image: https://engineering.jhu.edu/ece/wp-content/uploads/2021/06/etienne-cummings-ralph-300x300.jpg
 ---
 Prof. Etienne-Cummings leads the [Computational Sensory-Motor Systems Lab](https://engineering.jhu.edu/csms/) which has recently focused on research into brain-machine interfaces and neural prosthesis devices. Other areas of research he has contributed to include neurally inspired control for legged robots, development of neural prosthetic devices, and image and video analysis.
-* Tenore, Francesco, et al. "[Towards the control of individual fingers of a prosthetic hand using surface EMG signals.](https://pubmed.ncbi.nlm.nih.gov/18003418/)" 2007 29th Annual International Conference of the IEEE Engineering in Medicine and Biology Society. IEEE, 2007.
+* Aboumerhi, Khaled, et al. "[Neuromorphic applications in medicine.](https://iopscience.iop.org/article/10.1088/1741-2552/aceca3/pdf)" Journal of Neural Engineering 20.4 (2023): 041004.
 * Lewis, M. Anthony, Francesco Tenore, and Ralph Etienne-Cummings. "[CPG design using inhibitory networks.](https://ieeexplore.ieee.org/document/1570681)" Proceedings of the 2005 IEEE international conference on robotics and automation. IEEE, 2005.
 * Dong, Fengchun, et al. "[Plenoptic cameras in real-time robotics.](https://journals.sagepub.com/doi/abs/10.1177/0278364912469420)" The International Journal of Robotics Research 32.2 (2013): 206-217.


### PR DESCRIPTION
I've reviewed the second quarter of the Black in Robotics Reading List, from Chinwe Ekenna to Michelle Johnson. I also made updates to Chris Crawford and Christine Allen-Blanchette's pages.

Some important changes to note: Maynard Holliday is now the former Assistant Secretary of Defense for Critical Technologies. Daniel Jacobs no longer leads the RISE lab, and is now the Chair (Engineering and Robotics Department) in Springside Chestnut Hill Academy.

Reviewed:

1. Chinwe Ekenna
2. Ralph Etienne-Cummings
3. Stephen J. Guy
4. Frank L. Hammond III
5. Maynard Holliday, MSc
6. Ayanna Howard
7. Charles Isbell
8. Daniel Jacobs
9. Odest Chadwicke Jenkins
10. Michelle Johnson
11. Chris Crawford
12. Christine Allen-Blanchette